### PR TITLE
change alignment method to sign flipping

### DIFF
--- a/scripts/12.connectivity_JE.py
+++ b/scripts/12.connectivity_JE.py
@@ -42,7 +42,7 @@ print(f"\tdiffusion times: {diffusion_times}\n\n")
 
 je = JointEmbedding(method="dme",
                     n_components=n_components,
-                    alignment="rotation",
+                    alignment="sign_flip",
                     random_state=0,
                     copy=True)
 
@@ -65,10 +65,10 @@ for key, kwargs in kwarg_dict.items():
     print(f"\t\N{GREEK SMALL LETTER ALPHA}={kwargs['alpha']} t={kwargs['diffusion_time']} :\t done")
 
 # Save outut
-filename = subj.outpath(f'{ID}.FC_embeddings.npz')
+filename = subj.outpath(f'{ID}.FC_embeddings_flip.npz')
 npz_update(filename,  embedding_dict)
 print(f"Subject embeddings saved in archive {filename} \n")
 
-filename = subj.outpath(f'{ID}.FC_embeddings_refs.npz')
+filename = subj.outpath(f'{ID}.FC_embeddings_flip_refs.npz')
 npz_update(filename,  reference_dict)
 print(f"Reference embeddings saved in archive {filename} \n")

--- a/scripts/12b.connectivity_JE_hemi.py
+++ b/scripts/12b.connectivity_JE_hemi.py
@@ -56,7 +56,7 @@ for h in ["L", "R"]:
     
     je = JointEmbedding(method="dme",
                         n_components=n_components,
-                        alignment="rotation",
+                        alignment="sign_flip",
                         random_state=0,
                         copy=True)
     
@@ -69,10 +69,10 @@ for h in ["L", "R"]:
         print(f"\t\N{GREEK SMALL LETTER ALPHA}={kwargs['alpha']} t={kwargs['diffusion_time']} :\t done")
 
 # Save output
-filename = subj.outpath(f'{ID}.FC_embeddings_hemi.npz')
+filename = subj.outpath(f'{ID}.FC_embeddings_flip_hemi_refs.npz')
 npz_update(filename,  embedding_dict)
 print(f"Subject embeddings saved in archive {filename} \n")
 
-filename = subj.outpath(f'{ID}.FC_embeddings_refs_hemi.npz')
+filename = subj.outpath(f'{ID}.FC_embeddings_flip_hemi_refs.npz')
 npz_update(filename,  reference_dict)
 print(f"Reference embeddings saved in archive {filename} \n")


### PR DESCRIPTION
Other additional alignments seem to force excessive similarity between subjects. Since the embedding is already joint fit the reference for this study simply flipping the sign of gradients when necessary seems enough.